### PR TITLE
Link ICU data (small or full) on Windows. Also need to fixup the Unixy build again.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ EXPERIMENTAL: alternate ICU support
 
 
    * Some rough edges on Windows.
-      * for windows, add `small-icu` or `full-icu` to vcbuild params. (WIP)
-      * As of this writing only `full-icu` will build, BUT will require
-      setting `NODE_ICU_DATA` or using `--icu-data-dir` to function. (WIP.)
+      * for windows, add `full-icu` to vcbuild params.
+      * (`small-icu` not working - WIP)
    * Builds a restricted ICU set
       * English and Root data only
       * Only the services needed by v8's Intl implementation

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ EXPERIMENTAL: alternate ICU support
     make install
 
 
-   * Some rough edges on Windows.
-      * for windows, add `full-icu` to vcbuild params.
-      * (`small-icu` not working - WIP)
+   * Windows instructions:
+      * add `full-icu` or `small-icu` to vcbuild params.
+      * also, you will need to get `icudt53l.dat`:
+      	* download ICU 53 source (.zip) from http://site.icu-project.org/download
+	* copy `icu/source/data/in/icudt53l.dat` from the source zip 
+	   to `deps/icu/source/data/in/icudt53l.dat`
    * Builds a restricted ICU set
       * English and Root data only
       * Only the services needed by v8's Intl implementation

--- a/configure
+++ b/configure
@@ -683,7 +683,6 @@ configure_winsdk(output)
 def glob_to_var(dir_base, dir_sub):
   list = []
   dir_all = os.path.join(dir_base, dir_sub)
-  print "globbing %s + %s = %s" % (dir_base,dir_sub, dir_all)
   files = os.walk(dir_all)
   for ent in files:
     (path,dirs,files) = ent
@@ -694,7 +693,8 @@ def glob_to_var(dir_base, dir_sub):
   return list
 
 def configure_icu(o):
-  # todo(srl295): move this into a separate module if it is too long?
+  # todo(srl295): move this into a separate module if it is too big?
+  # todo(srl295): move the output into a separate config_icu.gypi?
   have_icu_path = bool(options.with_icu_path)
   have_generic_icu = bool(options.with_generic_icu)
   i18n_support = int(have_icu_path | have_generic_icu)
@@ -711,11 +711,34 @@ def configure_icu(o):
     o['variables']['icu_full'] = b(options.with_full_icu)
     o['variables']['icu_path'] = icu_full_path
     print 'Building from generic ICU in %s' % (options.with_generic_icu)
-    print 'Configuring and building ICU into out/deps/icu'
+    if not os.path.isdir(icu_full_path):
+      print 'Error: ICU path is not a directory: %s' % (icu_full_path)
+      sys.exit(1)
+    print 'Configuring and building ICU from %s into out/deps/icu' % (icu_full_path)
     if flavor == 'win':
+      # TODO srl295 - fixme!!! Should extract icu_ver from icu's uvernum.h and not hard-code it.
+      icu_ver_major='53'
+      o['variables']['icu_ver_major'] = icu_ver_major
+      # Note that we hardcode 'l' here for Little-Endian. This is the default prebuilt form.
+      icu_data_in=os.path.join(icu_full_path, 'source\\data\\in\\icudt%sl.dat' % (icu_ver_major))
+      if not os.path.isfile(icu_data_in):
+        # we need a generated .dat file.
+        # we're not about to build all of the specialized tools
+        # needed here.
+        print 'Error: ICU prebuilt data file %s does not exist. ' % (icu_data_in)
+        print 'Hint: a source download from http://icu-project.org/download'
+        print ' will contain this file, or a "normal" ICU build will'
+        print ' build it,'
+        print ' or you could generate one from http://apps.icu-project.org/datacustom'
+        sys.exit(1)
+      o['variables']['icu_data_in'] = icu_data_in
       o['variables']['icu_src_stubdata'] = glob_to_var('deps', 'icu\\source\\stubdata')
       o['variables']['icu_src_common'] = glob_to_var('deps', 'icu\\source\\common')
       o['variables']['icu_src_i18n'] = glob_to_var('deps', 'icu\\source\\i18n')
+      o['variables']['icu_src_tools'] = glob_to_var('deps', 'icu\\source\\tools\\toolutil')
+      o['variables']['icu_src_genrb'] = glob_to_var('deps', 'icu\\source\\tools\\genrb')
+      o['variables']['icu_src_icupkg'] = glob_to_var('deps', 'icu\\source\\tools\\icupkg')
+      o['variables']['icu_src_genccode'] = glob_to_var('deps', 'icu\\source\\tools\\genccode')
       o['variables']['icu_gyp_path'] = 'deps/icu-generic-win.gyp'
     else:
       o['variables']['icu_gyp_path'] = 'deps/icu-generic.gyp'

--- a/configure
+++ b/configure
@@ -735,6 +735,7 @@ def configure_icu(o):
       o['variables']['icu_src_stubdata'] = glob_to_var('deps', 'icu\\source\\stubdata')
       o['variables']['icu_src_common'] = glob_to_var('deps', 'icu\\source\\common')
       o['variables']['icu_src_i18n'] = glob_to_var('deps', 'icu\\source\\i18n')
+      o['variables']['icu_src_io'] = glob_to_var('deps', 'icu\\source\\io')
       o['variables']['icu_src_tools'] = glob_to_var('deps', 'icu\\source\\tools\\toolutil')
       o['variables']['icu_src_genrb'] = glob_to_var('deps', 'icu\\source\\tools\\genrb')
       o['variables']['icu_src_icupkg'] = glob_to_var('deps', 'icu\\source\\tools\\icupkg')

--- a/deps/icu-generic-win.gyp
+++ b/deps/icu-generic-win.gyp
@@ -112,9 +112,16 @@
           'export_dependent_settings': ['icustubdata'],
           'actions': [
             {
-              # FOR NOW - 'small' == 'full'.
-              'action_name': 'icudata',
+              # trim down ICU
+              'action_name': 'icutrim',
               'inputs': [ 'icu/source/data/in/icudt53l.dat' ], # TODO: make a param obviously.
+              'outputs': [ '../out/icutmp/icudt53l.dat' ], ## TODO fix
+              'action': [ 'icu/as_is/iculslocs/icutrim.py -P ../Release -D <@(_inputs) --delete-tmp -T ../out/icutmp -F icu/as_is/iculslocs/trim_en.json -O icudt53l.dat -v' ],
+            },
+            {
+              # build final .dat -> .obj
+              'action_name': 'genccode',
+              'inputs': [ '../out/icutmp/icudt53l.dat' ], # TODO: make a param obviously.
               'outputs': [ '../out/icudt53l_dat.obj' ], ## TODO fix
               'action': [ '../Release/genccode -o -d ../out/ -n icudata -e icusmdt53 <@(_inputs)' ],
             },

--- a/deps/icu-generic-win.gyp
+++ b/deps/icu-generic-win.gyp
@@ -142,7 +142,7 @@
     },
     {
       'target_name': 'icutools',
-      'target-type': '<(library)',
+      'type': '<(library)',
       'dependencies': ['icuucx','icui18n','icustubdata'],
       'sources': [
         '<@(icu_src_tools)'
@@ -156,14 +156,14 @@
           'deps/icu/toolutil',
         ],
       },
-      'export_dependent_settings': ['icuuc','icui18n','icustubdata'],
+      'export_dependent_settings': ['icuucx','icui18n','icustubdata'],
     },
     # TODO: may not need this, at least for full-icu.
     # It is needed to rebuild .res files from .txt,
     # or to build index (res_index.txt) files, though.
     {
       'target_name': 'genrb',
-      'target-type': 'executable',
+      'type': 'executable',
       'dependencies': ['icutools','icuucx','icui18n'],
       'sources': [
         '<@(icu_src_genrb)'
@@ -173,7 +173,7 @@
     # and convert endianesses
     {
       'target_name': 'icupkg',
-      'target-type': 'executable',
+      'type': 'executable',
       'dependencies': ['icutools','icuucx','icui18n'],
       'sources': [
         '<@(icu_src_icupkg)'
@@ -182,7 +182,7 @@
     # this is used to convert .dat directly into .obj. Do not pass go, do not collect US$200.
     {
       'target_name': 'genccode',
-      'target-type': 'executable',
+      'type': 'executable',
       'dependencies': ['icutools','icuucx','icui18n'],
       'sources': [
         '<@(icu_src_genccode)'

--- a/deps/icu-generic-win.gyp
+++ b/deps/icu-generic-win.gyp
@@ -68,16 +68,17 @@
     # TODO(srl295): for 'small ICU' depend on genccode, icupkg, and a cast of 1000s
     {
       'target_name': 'icudata',
-      'type': 'none',
+      'type': '<(library)',
       'dependencies': ['genccode'],
       'actions': [
         {
           'action_name': 'icudata',
           'inputs': [ 'icu/source/data/in/icudt53l.dat' ], # TODO: make a param obviously.
-          'outputs': [ '../out/icudata.obj' ], ## TODO fix
-          'action': [ 'genccode -o -d ../out/ -n icudata -e icudt53 <@(_inputs)' ],
+          'outputs': [ '../out/icudt53l_dat.obj' ], ## TODO fix
+          'action': [ '../Release/genccode -o -d ../out/ -n icudata -e icudt53 <@(_inputs)' ],
         },
       ],
+      'sources': [ '../out/icudt53l_dat.obj' ],
     },
     # this means "no data". It's a tiny (~1k) symbol with no ICU data in it.
     # tools must link against it as they are generating the full data.

--- a/deps/icu-generic.gyp
+++ b/deps/icu-generic.gyp
@@ -34,8 +34,6 @@
       },
       'export_dependent_settings': ['icuuc'],
     },
-    ## TODO: need to add 'icudatan', 'icuucx', and other breakage
-    ## to deal with upstream v8 stuff. see icu-generic-win.gyp
     {
       'target_name': 'icudata',
       'type': 'none',

--- a/deps/icu-generic.gyp
+++ b/deps/icu-generic.gyp
@@ -34,6 +34,8 @@
       },
       'export_dependent_settings': ['icuuc'],
     },
+    ## TODO: need to add 'icudatan', 'icuucx', and other breakage
+    ## to deal with upstream v8 stuff. see icu-generic-win.gyp
     {
       'target_name': 'icudata',
       'type': 'none',

--- a/deps/icu-trim.py
+++ b/deps/icu-trim.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+importr os
+import optparse
+import re
+import subprocess
+import sys
+
+root_dir = os.path.dirname(__file__)
+
+parser = optparse.OptionParser()
+
+parser.add_options('-P',
+                   action='store',
+                   dest='toolpath',
+                   help='directory containing tools such as icupkg')
+
+parser.add_options('-D',
+                   action='store',
+                   dest='datfile',
+                   help='input data file (icudt__.dat)')
+
+parser.add_options('-F',
+                   action='store',
+                   dest='filterfile',
+                   help='filter file (controls items to include/exclude)')
+
+parser.add_options('-T',
+                   action='store',
+                   dest='tmpdir',
+                   help='working directory, will also contain output file')
+
+(options, args) = parser.parse_args()
+

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -59,7 +59,7 @@
 #define SMALL_DEF(major, suff) icusmdt##suff##major##_dat
 #endif
 
-extern "C" const char U_IMPORT SMALL_ICUDATA_ENTRY_POINT[];
+extern "C" const char U_DATA_API SMALL_ICUDATA_ENTRY_POINT[];
 #endif
 
 


### PR DESCRIPTION
build: i18n: This adds `icu-small` and `icu-full` options to the vcbuild.bat script.  note `README.md` about dependencies.
