### PR TITLE
build: support --icu-data-dir configure switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ PYTHON ?= python
 NINJA ?= ninja
 DESTDIR ?=
 SIGN ?=
-PREFIX ?= /usr/local
 
 NODE ?= ./node
 
@@ -294,10 +293,10 @@ pkg: $(PKG)
 $(PKG): release-only
 	rm -rf $(PKGDIR)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --without-snapshot --dest-cpu=ia32 --tag=$(TAG)
+	$(PYTHON) ./configure --icu-data-dir=share/node/i18n --without-snapshot --dest-cpu=ia32 --tag=$(TAG)
 	$(MAKE) install V=$(V) DESTDIR=$(PKGDIR)/32
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --without-snapshot --dest-cpu=x64 --tag=$(TAG)
+	$(PYTHON) ./configure --icu-data-dir=share/node/i18n --without-snapshot --dest-cpu=x64 --tag=$(TAG)
 	$(MAKE) install V=$(V) DESTDIR=$(PKGDIR)
 	SIGN="$(APP_SIGN)" PKGDIR="$(PKGDIR)" bash tools/osx-codesign.sh
 	lipo $(PKGDIR)/32/usr/local/bin/node \

--- a/configure
+++ b/configure
@@ -262,6 +262,11 @@ parser.add_option('--with-icu-source',
     dest='with_icu_source',
     help='Intl mode: optional local path to icu/ dir, or path/URL of icu source archive.')
 
+parser.add_option('--icu-data-dir',
+    action='store',
+    dest='icu_data_dir',
+    help='Path to the directory from which ICU loads its data')
+
 parser.add_option('--with-perfctr',
     action='store_true',
     dest='with_perfctr',
@@ -494,7 +499,7 @@ def configure_arm(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
-  o['variables']['node_prefix'] = os.path.expanduser(options.prefix or '')
+  o['variables']['node_prefix'] = expanded_prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'
 
@@ -769,9 +774,28 @@ def configure_intl(o):
 
   # always set icu_small, node.gyp depends on it being defined.
   o['variables']['icu_small'] = b(False)
+  # Unless we specify --icu-data-dir or --with-intl=stub-icu at configure
+  # time, then the ICU data embedded in node's binary is not the stubbed data
+  o['variables']['icu_stub'] = b(False)
 
   with_intl = options.with_intl
   with_icu_source = options.with_icu_source
+
+  if options.icu_data_dir:
+    options.icu_data_dir = os.path.expanduser(options.icu_data_dir)
+    o['variables']['icu_data_dir'] = options.icu_data_dir
+
+    icu_data_dir_define = options.icu_data_dir
+    if not os.path.isabs(icu_data_dir_define):
+      icu_data_dir_define = os.path.join(expanded_prefix,
+                                         icu_data_dir_define)
+    o['defines'] += [ 'ICU_DATA_DIR="' + icu_data_dir_define + '"']
+
+    # When supplying --icu-data-dir, the node binary is linked to ICU's stub
+    # data. The actual ICU data is generated in a separate file and is loaded
+    # from the dir pointed to by --icu-data-dir
+    with_intl = 'stub-icu'
+
   have_icu_path = bool(options.with_icu_path)
   if have_icu_path and with_intl:
     print 'Error: Cannot specify both --with-icu-path and --with-intl'
@@ -806,6 +830,9 @@ def configure_intl(o):
   elif with_intl == 'full-icu':
     # full ICU
     o['variables']['v8_enable_i18n_support'] = 1
+  elif with_intl == 'stub-icu':
+    o['variables']['v8_enable_i18n_support'] = 1
+    o['variables']['icu_stub'] = b(True)
   elif with_intl == 'system-icu':
     # ICU from pkg-config.
     o['variables']['v8_enable_i18n_support'] = 1
@@ -979,6 +1006,8 @@ output = {
   'cflags': [],
 }
 
+expanded_prefix = os.path.expanduser(options.prefix or
+  '/usr/local')
 configure_node(output)
 configure_libz(output)
 configure_http_parser(output)
@@ -1010,8 +1039,7 @@ config = {
   'PYTHON': sys.executable,
 }
 
-if options.prefix:
-  config['PREFIX'] = options.prefix
+config['PREFIX'] = expanded_prefix
 
 config = '\n'.join(map('='.join, config.iteritems())) + '\n'
 

--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -354,8 +354,30 @@
           'export_dependent_settings': [ 'icutools' ],
         }],
         ['_toolset=="target"', {
-          'dependencies': [ 'icuucx', 'icudata' ],
-          'export_dependent_settings': [ 'icuucx', 'icudata' ],
+          'conditions': [
+            [ 'icu_stub == "false"',
+              {
+                'dependencies': [ 'icuucx', 'icudata' ],
+                'export_dependent_settings': [ 'icuucx', 'icudata' ]
+              },
+              {
+                'dependencies': [ 'icuucx', 'icustubdata', 'icupkg#host' ],
+                'export_dependent_settings': [ 'icuucx', 'icustubdata' ],
+                'actions': [
+                {
+                   # Swap endianness (if needed), or at least copy the file
+                   'action_name': 'icupkg',
+                   'inputs': [ '<(icu_data_in)' ],
+                   'outputs':[ '<(SHARED_INTERMEDIATE_DIR)/<(icu_data_file)' ],
+                   'action': [ '<(PRODUCT_DIR)/icupkg',
+                               '-t<(icu_endianness)',
+                               '<@(_inputs)',
+                               '<@(_outputs)',
+                             ],
+                }],
+              },
+            ],
+          ],
         }],
       ],
     },

--- a/tools/install.py
+++ b/tools/install.py
@@ -25,6 +25,7 @@ def abspath(*args):
 def load_config():
   s = open('config.gypi').read()
   s = re.sub(r'#.*?\n', '', s) # strip comments
+  s = re.sub(r'"', '\\"', s) # escape double quotes
   s = re.sub(r'\'', '"', s) # convert quotes
   return json.loads(s)
 
@@ -171,6 +172,12 @@ def files(action):
       'deps/zlib/zconf.h',
       'deps/zlib/zlib.h',
     ], 'include/node/')
+
+  icu_data_dir = variables.get('icu_data_dir')
+  if None != icu_data_dir:
+    icu_data_file = variables.get('icu_data_file')
+    action([os.path.join('out/Release', icu_data_file)],
+            os.path.join(icu_data_dir, icu_data_file))
 
 def run(args):
   global node_prefix, install_path, target_defaults, variables


### PR DESCRIPTION
A few comments about this PR:
- We may want to remove the usage of `--icu-data-dir` in the `Makefile`'s target that builds the OS X package, since we haven't solved the cross-compilation issue (see #12) yet and we need it for OS X packages.

**EDIT**: the cross-compilation issue has been fixed by a recent change in the [srl-v0.12-autoicu branch](https://github.com/srl295/node/commit/b04809223dccb4e1023c5992943141bf565a0ced#diff-eda374a7b1c3fccd439785b07caa1372R460).
- It seems that our current V8 doesn't handle the situation when ICU is linked with only the stubbed data and the .dat file cannot be found. It segfaults with the following call stack:

```
* thread #1: tid = 0x266c56, 0x000000010035a5b3 node`v8::internal::(anonymous namespace)::SetResolvedDateSettings(isolate=0x0000000101804c00, icu_locale=0x00007fff5fbfea80, date_format=0x0000000000000000, resolved=<unavailable>) + 99 at i18n.cc:132, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000010035a5b3 node`v8::internal::(anonymous namespace)::SetResolvedDateSettings(isolate=0x0000000101804c00, icu_locale=0x00007fff5fbfea80, date_format=0x0000000000000000, resolved=<unavailable>) + 99 at i18n.cc:132
   129    Factory* factory = isolate->factory();
   130    UErrorCode status = U_ZERO_ERROR;
   131    icu::UnicodeString pattern;
-> 132    date_format->toPattern(pattern);
   133    JSObject::SetProperty(
   134        resolved,
   135        factory->NewStringFromStaticAscii("pattern"),
(lldb) bt
* thread #1: tid = 0x266c56, 0x000000010035a5b3 node`v8::internal::(anonymous namespace)::SetResolvedDateSettings(isolate=0x0000000101804c00, icu_locale=0x00007fff5fbfea80, date_format=0x0000000000000000, resolved=<unavailable>) + 99 at i18n.cc:132, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x000000010035a5b3 node`v8::internal::(anonymous namespace)::SetResolvedDateSettings(isolate=0x0000000101804c00, icu_locale=0x00007fff5fbfea80, date_format=0x0000000000000000, resolved=<unavailable>) + 99 at i18n.cc:132
    frame #1: 0x000000010035a351 node`v8::internal::DateFormat::InitializeDateTimeFormat(isolate=0x0000000101804c00, locale=<unavailable>, options=<unavailable>, resolved=<unavailable>) + 353 at i18n.cc:775
    frame #2: 0x000000010045bdaa node`v8::internal::Runtime_CreateDateTimeFormat(int, v8::internal::Object**, v8::internal::Isolate*) [inlined] v8::internal::__RT_impl_Runtime_CreateDateTimeFormat(isolate=0x0000000101804c00, arguments=0x00007fff5fbff048) + 185 at runtime.cc:14055
    frame #3: 0x000000010045bcf1 node`v8::internal::Runtime_CreateDateTimeFormat(args_length=<unavailable>, args_object=0x00007fff5fbff048, isolate=0x0000000101804c00) + 17 at runtime.cc:14036
    frame #4: 0x000027480ab0740e
    frame #5: 0x000027480aba9d00
    frame #6: 0x000027480aba9688
    frame #7: 0x000027480ab07b75
    frame #8: 0x000027480ab32de2
    frame #9: 0x000027480aba94bf
    frame #10: 0x000027480aba7d03
    frame #11: 0x000027480aba7ac9
    frame #12: 0x000027480ab07b75
    frame #13: 0x000027480aba55e7
    frame #14: 0x000027480ab5e0a6
    frame #15: 0x000027480aba43a6
    frame #16: 0x000027480ab9e9ac
    frame #17: 0x000027480ab9b1e0
    frame #18: 0x000027480ab91d45
    frame #19: 0x000027480ab91704
    frame #20: 0x000027480ab6451f
    frame #21: 0x000027480ab62f10
    frame #22: 0x000027480ab5b1c0
    frame #23: 0x000027480ab28d31
    frame #24: 0x0000000100210603 node`v8::internal::Invoke(is_construct=<unavailable>, argc=1, args=0x00007fff5fbff7f8, function=<unavailable>, receiver=<unavailable>) + 419 at execution.cc:91
    frame #25: 0x0000000100123d6f node`v8::Function::Call(this=0x0000000101858418, argc=1, argv=0x00007fff5fbff7f8, recv=<unavailable>) + 207 at api.cc:4019
    frame #26: 0x0000000100541ce9 node`node::LoadEnvironment(env=0x0000000101803000) + 517 at node.cc:2868
    frame #27: 0x0000000100542f0a node`node::Start(argc=2, argv=<unavailable>) + 305 at node.cc:3696
    frame #28: 0x0000000100000b74 node`start + 52
(lldb)
```

It seems that we should at least make V8 exits more gracefully with an error message that indicates the cause of the error. 
- Defining the `ICU_DATA_DIR` macro with a relative path cannot work, as ICU would try to load the `.dat` file relative to the current working directory. Thus, the `configure` script either needs to always get an absolute path for `--icu-data-dir`, or it needs to know about the installation prefix. This is why in this PR the prefix definition has been moved from `Makefile` to `configure`.

Fixes #13.
