### PR TITLE
build: i18n: Don't auto-download ICU unless --download=all

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,19 +91,19 @@ enabled by default.
 #### "small" (English only) support
 
 This option will build with "small" (English only) support, but
-the full `Intl` (ECMA-402) APIs. It will download the ICU library
-as needed.
+the full `Intl` (ECMA-402) APIs.  With `--download=all` it will
+download the ICU library as needed.
 
 Unix/Macintosh:
 
 ```sh
-./configure --with-intl=small-icu
+./configure --with-intl=small-icu --download=all
 ```
 
 Windows:
 
 ```sh
-vcbuild small-icu
+vcbuild small-icu download-all
 ```
 
 The `small-icu` mode builds
@@ -114,18 +114,19 @@ with English-only data. You can add full data at runtime.
 
 #### Build with full ICU support (all locales supported by ICU):
 
-*Note*, this may download ICU if you don't have an ICU in `deps/icu`
+With the `--download=all`, this may download ICU if you don't
+have an ICU in `deps/icu`.
 
 Unix/Macintosh:
 
 ```sh
-./configure --with-intl=full-icu
+./configure --with-intl=full-icu --download=all
 ```
 
 Windows:
 
 ```sh
-vcbuild full-icu
+vcbuild full-icu download-all
 ```
 
 #### Build with no Intl support `:-(`

--- a/configure
+++ b/configure
@@ -242,6 +242,11 @@ parser.add_option('--with-etw',
     dest='with_etw',
     help='build with ETW (default is true on Windows)')
 
+parser.add_option('--download',
+    action='store',
+    dest='download_list',
+    help=nodedownload.help())
+
 parser.add_option('--with-icu-path',
     action='store',
     dest='with_icu_path',
@@ -310,6 +315,8 @@ parser.add_option('--xcode',
 
 (options, args) = parser.parse_args()
 
+# set up auto-download list
+auto_downloads = nodedownload.parse(options.download_list)
 
 def b(value):
   """Returns the string 'true' if value is truthy, 'false' otherwise."""
@@ -743,7 +750,8 @@ def configure_intl(o):
       local = url.split('/')[-1]
       targetfile = os.path.join(root_dir, 'deps', local)
       if not os.path.isfile(targetfile):
-        nodedownload.retrievefile(url, targetfile)
+        if nodedownload.candownload(auto_downloads, "icu"):
+          nodedownload.retrievefile(url, targetfile)
       else:
         print ' Re-using existing %s' % targetfile
       if os.path.isfile(targetfile):

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -36,6 +36,7 @@ set noperfctr=
 set noperfctr_arg=
 set noperfctr_msi_arg=
 set i18n_arg=
+set download_arg=
 
 :next-arg
 if "%1"=="" goto args-done
@@ -66,6 +67,7 @@ if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 if /i "%1"=="small-icu"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
 if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
+if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 
 echo Warning: ignoring invalid command line option `%1`.
 
@@ -97,7 +99,7 @@ if defined NIGHTLY set TAG=nightly-%NIGHTLY%
 @rem Generate the VS project.
 SETLOCAL
   if defined VS100COMNTOOLS call "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat"
-  python configure %i18n_arg% %debug_arg% %nosnapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
+  python configure %download_arg% %i18n_arg% %debug_arg% %nosnapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
   if errorlevel 1 goto create-msvs-files-failed
   if not exist node.sln goto create-msvs-files-failed
   echo Project files generated.
@@ -234,7 +236,7 @@ python tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --noj
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build


### PR DESCRIPTION
Instead of downloading ICU if missing from `deps/icu`, just print a warning
unless either `--download=all` or `--download=icu` is set.

Add some generic scaffolding in case other modules end up in the same boat
in the future.

It's harmless to pass `--download=xyzzy`, so, future proof
(at least until some xyzzy dependency is integrated).

//cc: @tjfontaine @misterdjules @trevnorris - as per today's node.js sync call
